### PR TITLE
Adds support for Buzzard version of challenge dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ This will put you in a shell with all requirements.
 
 ## Getting training data
 
-Run `python -m tomo_challenge.data` in this directory to download the full set of challenge data, about 4.5GB.  You can also get the individual files from here if you prefer:  https://portal.nersc.gov/project/lsst/txpipe/tomo_challenge_data/
+Run `python -m tomo_challenge.data` in this directory to download the full set of challenge data, about 6.GB.  You can also get the individual files from here if you prefer:  https://portal.nersc.gov/project/lsst/txpipe/tomo_challenge_data/
+
+You will get two datasets, based on two different simulations, which will allow us to test different assumptions about galaxy SEDs.
+The first dataset, which can be found under `data` after download is based on the CosmoDC2 simulation. The second dataset, found under
+`data_buzzard` is based on the Buzzard simulations.
 
 
 ## Metric
@@ -125,7 +129,7 @@ swig
 libopenmpi-dev
 liblapack3
 liblapack64-dev
-libopenblas-dev 
+libopenblas-dev
 ```
 
 - **What are the metrics?**
@@ -155,7 +159,8 @@ This only affects shear catalogs - for lens bins we can do what we like.
 
 - **What is the input data?**
 
-[CosmoDC2](https://arxiv.org/pdf/1907.06530.pdf) galaxies with mock noise added.
+  - [CosmoDC2](https://arxiv.org/pdf/1907.06530.pdf) galaxies with mock noise added.
+  - Buzzard galaxies with mock noise added.  
 
 ---
 
@@ -218,4 +223,3 @@ The end of August 2020. (We have updated this from July 2020 since we felt it wa
 - **What does the winner get?**
 
 Recognition.
-

--- a/example/example_buzzard.yaml
+++ b/example/example_buzzard.yaml
@@ -1,0 +1,21 @@
+metrics:  [SNR_ww, SNR_3x2, FOM_3x2]
+bands: riz
+training_file: data_buzzard/training.hdf5
+validation_file: data_buzzard/validation.hdf5
+output_file: example/example_output_buzzard.txt
+
+run:
+  # This is a class name which will be looked up
+  RandomForest:
+    run_3:
+      # This setting is sent to the classifier
+      bins: 3
+      # These special settings decide whether the
+      # color and error colums are passed to the classifier
+      # as well as the magnitudes
+      colors: True
+      errors: False
+
+  IBandOnly:
+    run_3:
+      bins: 3

--- a/tomo_challenge/data.py
+++ b/tomo_challenge/data.py
@@ -4,12 +4,17 @@ import warnings
 import h5py
 import numpy as np
 
+# Path to original challenge dataset
 nersc_path = '/global/projecta/projectdirs/lsst/groups/WL/users/zuntz/tomo_challenge_data/ugrizy'
 url_root =  'https://portal.nersc.gov/cfs/lsst/txpipe/tomo_challenge_data/ugrizy'
+
+# Path to Buzzard version of the challenge dataset
+nersc_path_buzzard = '/global/projecta/projectdirs/lsst/groups/WL/users/flanusse/tomo_challenge_buzzard'
+url_root_buzzard =  'https://portal.nersc.gov/cfs/lsst/txpipe/tomo_challenge_data/ugrizy_buzzard'
+
 # This is not supposed to be needed - I don't understand why in my shifter env the warning
 # is being repeated.
 warned = False
-
 
 class MyProgressBar:
     def __init__(self):
@@ -36,9 +41,9 @@ class MyProgressBar:
 
 
 def download_data():
-    """Download challenge data (about 4GB) to current directory.
+    """Download challenge data (about 6GB) to current directory.
 
-    This will create a directory ./data with the training
+    This will create directories ./data with the training
     and validation files in.
 
     If on NERSC this will just generate links to the data.
@@ -53,7 +58,8 @@ def download_data():
     """
     if os.environ.get("NERSC_HOST"):
         # If we are on NERSC just make some links
-        os.symlink(nersc_path, 'data')
+        os.symlink(nersc_path, 'data/')
+        os.symlink(nersc_path_buzzard, 'data_buzzard/')
     else:
         # Otherwise actually download both data sets
         os.makedirs('data', exist_ok=True)
@@ -63,6 +69,13 @@ def download_data():
             progress = MyProgressBar()
             urlretrieve(f'{url_root}/{filename}', f'data/{filename}', reporthook=progress)
 
+        os.makedirs('data_buzzard', exist_ok=True)
+        # Download each of the two files for these bands
+        for f in ['validation', 'training']:
+            filename = f'{f}.hdf5'
+            progress = MyProgressBar()
+            urlretrieve(f'{url_root_buzzard}/{filename}', f'data_buzzard/{filename}', reporthook=progress)
+            
 
 def load_mags(filename, bands, errors=False):
 
@@ -170,7 +183,7 @@ def load_redshift(filename):
     f = h5py.File(filename, 'r')
     z = f['redshift_true'][:]
     f.close()
-    return z    
+    return z
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR simply adds the downloading of the buzzard version to the download script. And an example of running the default classifier on this new dataset.

To test it, just re-run:
```python
python -m tomo_challenge.data
```
that will add the new dataset in `data_buzzard`
and to try it:
```
python bin/challenge.py example/example_buzzard.yaml
```

Enjoy!