### PR TITLE
fix import bug for jax-metrics

### DIFF
--- a/tomo_challenge/jax_metrics.py
+++ b/tomo_challenge/jax_metrics.py
@@ -3,7 +3,7 @@ import numpy as onp
 from functools import partial
 
 try:
-    import jax.numpy as jnp
+    import jax.numpy as np
     from jax import lax, jit, vmap, grad
     import jax_cosmo as jc
     import jax


### PR DESCRIPTION
jax.numpy was imported as jnp but then all the rest of the code was using np. so this PR fixes that

This solves issue #26 