### PR TITLE
Fix long plot names by saving metadata separately and using a hash

### DIFF
--- a/bin/challenge.py
+++ b/bin/challenge.py
@@ -105,7 +105,8 @@ def run_one(classifier_name, bands, settings, train_data, train_z, valid_data,
 
     print ("Making some pretty plots...")
     name = str(classifier.__name__)
-    tc.metrics.plot_distributions(valid_z, results, f"plots/{name}_{settings}_{bands}.png")
+    code = abs(hash(str(settings)))
+    tc.metrics.plot_distributions(valid_z, results, f"plots/{name}_{code}_{bands}.png", metadata=settings)
 
     return scores
 

--- a/tomo_challenge/metrics.py
+++ b/tomo_challenge/metrics.py
@@ -227,7 +227,7 @@ def compute_mean_covariance(tomo_bin, z, what):
     return mu, C, galaxy_galaxy_tracer_bias
 
 
-def plot_distributions(z, tomo_bin, filename, nominal_edges=None):
+def plot_distributions(z, tomo_bin, filename, nominal_edges=None, metadata=None):
     import matplotlib.pyplot as plt
     fig = plt.figure()
     nbin = int(tomo_bin.max()) + 1
@@ -240,7 +240,8 @@ def plot_distributions(z, tomo_bin, filename, nominal_edges=None):
         for x in nominal_edges:
             plt.axvline(x, color='k', linestyle=':')
 
-    plt.savefig(filename)
+    metadata = {k:str(v) for k,v in metadata.items()}
+    plt.savefig(filename, metadata=metadata)
     plt.close()
 
 


### PR DESCRIPTION
Save filenames with a hash of config instead of all of it, and save the metadata in the image instead
Addresses issue #46 
